### PR TITLE
V1 - Multiple paths through a single spawned process

### DIFF
--- a/cjs/index.js
+++ b/cjs/index.js
@@ -54,7 +54,8 @@ const EVENTS = {
   IN_MOVE_SELF,
   IN_UNMOUNT,
   IN_CLOSE,
-  IN_MOVE
+  IN_MOVE,
+  byName: name => EVENTS[`IN_${name}`]
 };
 
 const wm = new WeakMap;
@@ -75,8 +76,8 @@ const clean = self => {
 module.exports = Object.assign(
   class INotifyWait extends EventEmitter {
     constructor(
-      path,               // a *single* string path representing
-                          // either a file or a folder
+      path,               // a single path, or a list of paths, each
+                          // representing either a file or a folder
       options = {
         exclude: null,    // a RegExp to exclude files (passed as shell argument)
         include: null,    // a RegExp to include files (passed as shell argument)
@@ -148,10 +149,14 @@ module.exports = Object.assign(
           args.push('-e', 'move');
       }
 
-      this.path = (path = resolve(path));
+      const paths = [].concat(path)
+                      .map(path => resolve(path))
+                      .sort((a, b) => b.length - a.length);
+      this.paths = paths;
+
       const inotifywait = spawn(
         'inotifywait',
-        args.concat(path),
+        args.concat(this.paths),
         {
           detached: true,
           stdio: ['ignore', 'pipe', 'pipe']
@@ -161,22 +166,24 @@ module.exports = Object.assign(
       const {stdout, stderr} = inotifywait;
       stderr.on('data', error.bind(this));
 
-      const pLength = path.length + 1;
       stdout.on('data', data => {
         const output = split.call(data, /[\r\n]+/);
         for (let i = 0, {length} = output; i < length; i++) {
           const line = output[i];
           if (line !== '') {
             const index = line.indexOf('|');
-            const events = line.slice(0, index).split(',');
-            const extras = line.slice(1 + index + pLength);
-            const hasExtras = 0 < extras.length;
-            for (let i = 0, {length} = events; i < length; i++) {
-              const type = EVENTS[`IN_${events[i]}`];
-              if (hasExtras)
-                this.emit(type, type, extras);
-              else
-                this.emit(type, type);
+            const events = line.slice(0, index).split(',').map(EVENTS.byName);
+            const fullPath = line.slice(1 + index);
+            for (let i = 0, {length} = paths; i < length; i++) {
+              const path = paths[i];
+              const pLength = path.length;
+              if (fullPath.slice(0, pLength) === path) {
+                const entry = line.slice(1 + index + pLength + 1);
+                for (let i = 0, {length} = events; i < length; i++) {
+                  const type = events[i];
+                  this.emit(type, {type, path, entry});
+                }
+              }
             }
           }
         }

--- a/test/index.js
+++ b/test/index.js
@@ -147,27 +147,27 @@ setTimeout(cleanUP, DELAY, () => {
     process.removeListener('uncaughtException', uncaughtException);
     writeFile('test.txt', '', () => {
       execSync('sync');
-      inw = new INotifyWait('test.txt', {events: INotifyWait.IN_CLOSE_WRITE});
-      inw.on(INotifyWait.IN_CLOSE_WRITE, info => {
-        assert(INotifyWait.IN_CLOSE_WRITE === info, 'expected IN_CLOSE_WRITE');
+      inw = new INotifyWait(['test.txt', 'node_modules'], {events: INotifyWait.IN_CLOSE_WRITE});
+      inw.on(INotifyWait.IN_CLOSE_WRITE, ({type}) => {
+        assert(INotifyWait.IN_CLOSE_WRITE === type, 'expected IN_CLOSE_WRITE');
         inw.stop();
         unlink('test.txt', () => {
           let created = false;
           inw = new INotifyWait('.', {recursive: true, events: INotifyWait.IN_CREATE | INotifyWait.IN_MODIFY});
-          inw.on(INotifyWait.IN_CREATE, (info, details) => {
-            assert(INotifyWait.IN_CREATE === info, 'expected IN_CREATE');
-            assert(details === 'another file.txt', 'expected details IN_CREATE');
+          inw.on(INotifyWait.IN_CREATE, ({type, entry}) => {
+            assert(INotifyWait.IN_CREATE === type, 'expected IN_CREATE');
+            assert(entry === 'another file.txt', 'expected details IN_CREATE');
             created = true;
           });
-          inw.on(INotifyWait.IN_MODIFY, (info, details) => {
-            assert(INotifyWait.IN_MODIFY === info, 'expected folder IN_MODIFY');
-            assert(details === 'another file.txt', 'expected details IN_MODIFY');
+          inw.on(INotifyWait.IN_MODIFY, ({type, entry}) => {
+            assert(INotifyWait.IN_MODIFY === type, 'expected folder IN_MODIFY');
+            assert(entry === 'another file.txt', 'expected details IN_MODIFY');
             assert(created, 'file was previously created');
             unlink('another file.txt', () => {
               inw.removeAllListeners();
-              inw.on(INotifyWait.IN_CREATE, (info, details) => {
-                assert(INotifyWait.IN_CREATE === info, 'expected recursive IN_CREATE');
-                assert(details === 'test/recursive.txt', 'expected recursive details IN_CREATE');
+              inw.on(INotifyWait.IN_CREATE, ({type, entry}) => {
+                assert(INotifyWait.IN_CREATE === type, 'expected recursive IN_CREATE');
+                assert(entry === 'test/recursive.txt', 'expected recursive details IN_CREATE');
                 inw.stop();
                 console.log('');
                 unlink('test/recursive.txt', Object);


### PR DESCRIPTION
Since `inotifywait` accepts multiple paths, it'd be silly to need more than one spawned subprocess to watch various places through the same rules and events.

This major release brings multiple paths to the plate, but it inevitably breaks the early v0 API, sending an object instead of multiple parameters per each event.

The object contains the following informations:

  * `type`, which is the event type that's been currently triggered
  * `path`, which is the initially registered path, once resolved
  * `entry`, which is optionally the file, or subpath, that has been modified

At this point this module can reflects all possibilities offered by `inotifywait`, so it should be final, unless new features are added to `inotifywait` itself 🎉